### PR TITLE
Adjust notes to be cross-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Please place logs either in a code block (press `M` in your browser for a GFM ch
 ### System information
 
 Your system information must include:
-- your Linux distro
-- your Desktop/Window Manager
+- your Linux distro or OS version
+- your Desktop/Window Manager (Linux only)
 - your Graphics card info (manufacturer, card version), any and all graphics driver versions
 - anything else that you think may be useful (mouse/keyboard, filesystem type, etc).
 


### PR DESCRIPTION
Seems like a prudent change since we are accepting issue reports from Mac and Windows users
